### PR TITLE
fixing video URL

### DIFF
--- a/posts/_posts/2026-05-19-IntuneCISCompliantAgent.md
+++ b/posts/_posts/2026-05-19-IntuneCISCompliantAgent.md
@@ -186,10 +186,8 @@ The end result is an agent that:
 - Keeps working across container restarts (entity_id looked up fresh each time)
 
 <video controls width="100%">
-  <source src="assets/videos/posts/FoundryIntuneAgent_v2.mp4" type="video/mp4">
+  <source src="https://www.cloud-devops.ninja/assets/videos/posts/FoundryIntuneAgent_v2.mp4" type="video/mp4">
 </video>
-
-
 ---
 
 ## What I learned (with a lot of help from Claude Code)


### PR DESCRIPTION
This pull request updates the video source URL in the `posts/_posts/2026-05-19-IntuneCISCompliantAgent.md` file to use an absolute path. This ensures the video loads correctly regardless of the hosting environment.

- Documentation update:
  * Changed the `<video>` source URL from a relative path to an absolute URL (`https://www.cloud-devops.ninja/assets/videos/posts/FoundryIntuneAgent_v2.mp4`) in the blog post to improve video accessibility.