### PR TITLE
fix repo url

### DIFF
--- a/posts/_posts/2026-05-19-IntuneCISCompliantAgent.md
+++ b/posts/_posts/2026-05-19-IntuneCISCompliantAgent.md
@@ -212,7 +212,7 @@ Here are a few things I want to add:
 
 ## Getting started
 
-The full code can be found in [this](https://github.com/cloud-devops-ninja/FoundryAgents/) repository.  
+The full code can be found in [this](https://github.com/cloud-devops-ninja/Foundry-Intune-CIS-Compliant-Agent) repository.  
 You will need:
 
 - An Azure subscription with AI Foundry and a model deployment


### PR DESCRIPTION
This pull request updates the documentation to point to the correct GitHub repository for the code reference.

Documentation update:

* Updated the repository link in `posts/_posts/2026-05-19-IntuneCISCompliantAgent.md` to reference the correct `Foundry-Intune-CIS-Compliant-Agent` repository.