### PR TITLE
fix repo url

### DIFF
--- a/posts/_posts/2026-05-19-IntuneCISCompliantAgent.md
+++ b/posts/_posts/2026-05-19-IntuneCISCompliantAgent.md
@@ -223,8 +223,8 @@ You will need:
 
 1. Clone the repo
 
-`git clone https://github.com/cloud-devops-ninja/FoundryAgents.git`  
-`cd FoundryAgents`
+`git clone https://github.com/cloud-devops-ninja/Foundry-Intune-CIS-Compliant-Agent.git`  
+`cd Foundry-Intune-CIS-Compliant-Agent`
 
 2. Copy `.env.example` to `.env` and fill in your credentials  
 (make sure .env is part of .gitignore and .dockerignore)


### PR DESCRIPTION
This pull request updates the setup instructions in the `2026-05-19-IntuneCISCompliantAgent.md` documentation to reference the correct repository name.

Documentation update:

* Updated the `git clone` and `cd` commands in the setup instructions to use the `Foundry-Intune-CIS-Compliant-Agent` repository instead of the previous repository.